### PR TITLE
Make the tests for the summary text more accepting of line breaks.

### DIFF
--- a/src/__tests__/pokemon-list.test.jsx
+++ b/src/__tests__/pokemon-list.test.jsx
@@ -125,7 +125,7 @@ describe("Pokemon list with 'Load more' button", () => {
 
     // Check that the summary correctly updated
     expect(
-      await screen.findByText("Displaying 12 of 12 results")
+      await screen.findByText(/Displaying 12 of 12 results/)
     ).toBeInTheDocument();
 
     // Check that 12 items are displayed

--- a/src/__tests__/pokemon-list.test.jsx
+++ b/src/__tests__/pokemon-list.test.jsx
@@ -73,7 +73,7 @@ describe("Pokemon list with 'Load more' button", () => {
     // Check that the summary correctly says how many items are shown
     expect(
       await screen.findByText(
-        `Displaying 5 of ${pokemonsResultPage1.count} results`
+        new RegExp(`Displaying 5 of ${pokemonsResultPage1.count} results`, 's')
       )
     ).toBeInTheDocument();
   });
@@ -89,7 +89,7 @@ describe("Pokemon list with 'Load more' button", () => {
     // Check that the summary correctly updated
     expect(
       await screen.findByText(
-        `Displaying 10 of ${pokemonsResultPage1.count} results`
+        new RegExp(`Displaying 10 of ${pokemonsResultPage1.count} results`, 's')
       )
     ).toBeInTheDocument();
 


### PR DESCRIPTION
Solutions which include
```
<p>Displaying {pokemons.length} of {totalNumOfPokemons} results.</p>
```
will show up as
```
<p>
  "Displaying "
  "5"
  " of "
  "1302"
  " results."
</p>
```
which is not detected by `.findByText` as it currently is.

This modification makes the tests for the summary text more accepting of line breaks caused by using `{}` within `<p></p>`.